### PR TITLE
Hover state for whole list item

### DIFF
--- a/thingmenn-frontend/src/widgets/list-item-image/styles.css
+++ b/thingmenn-frontend/src/widgets/list-item-image/styles.css
@@ -21,7 +21,8 @@
   background-size: cover;
 }
 
-.ListItemImage-image:hover {
+.ListItemImage-image:hover,
+a:hover .ListItemImage-image {
   transform: scale(1.05) translateZ(0);
   opacity: 1;
 }


### PR DESCRIPTION
Currently, the hover state of the image only shows when hovering the image part, not the party icon or the name part. The whole card is a long, so it should have a consistent hover state.
